### PR TITLE
Profiling Prepared Statements

### DIFF
--- a/src/BjyProfiler/Db/Adapter/Driver/Mysqli/ProfilingStatement.php
+++ b/src/BjyProfiler/Db/Adapter/Driver/Mysqli/ProfilingStatement.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace BjyProfiler\Db\Adapter\Driver\Mysqli;
+
+use BjyProfiler\Db\Profiler\Profiler;
+use Zend\Db\Adapter\Driver\Mysqli\Statement;
+
+class ProfilingStatement extends Statement
+{
+    protected $profiler;
+
+    public function execute($parameters = null)
+    {
+        $queryId = $this->getProfiler()->startQuery($this->getSql());
+        $result = parent::execute($parameters);
+        $this->getProfiler()->endQuery($queryId);
+
+        return $result;
+    }
+
+    public function setProfiler(Profiler $p)
+    {
+        $this->profiler = $p;
+        return $this;
+    }
+
+    public function getProfiler()
+    {
+        return $this->profiler;
+    }
+}

--- a/src/BjyProfiler/Db/Adapter/Driver/Pdo/ProfilingStatement.php
+++ b/src/BjyProfiler/Db/Adapter/Driver/Pdo/ProfilingStatement.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace BjyProfiler\Db\Adapter\Driver\Pdo;
+
+use BjyProfiler\Db\Profiler\Profiler;
+use Zend\Db\Adapter\Driver\Pdo\Statement;
+
+class ProfilingStatement extends Statement
+{
+    protected $profiler;
+
+    public function execute($parameters = null)
+    {
+        $queryId = $this->getProfiler()->startQuery($this->getSql());
+        $result = parent::execute($parameters);
+        $this->getProfiler()->endQuery($queryId);
+
+        return $result;
+    }
+
+    public function setProfiler(Profiler $p)
+    {
+        $this->profiler = $p;
+        return $this;
+    }
+
+    public function getProfiler()
+    {
+        return $this->profiler;
+    }
+}

--- a/src/BjyProfiler/Db/Adapter/Driver/Pgsql/ProfilingStatement.php
+++ b/src/BjyProfiler/Db/Adapter/Driver/Pgsql/ProfilingStatement.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace BjyProfiler\Db\Adapter\Driver\Pgsql;
+
+use BjyProfiler\Db\Profiler\Profiler;
+use Zend\Db\Adapter\Driver\Pgsql\Statement;
+
+class ProfilingStatement extends Statement
+{
+    protected $profiler;
+
+    public function execute($parameters = null)
+    {
+        $queryId = $this->getProfiler()->startQuery($this->getSql());
+        $result = parent::execute($parameters);
+        $this->getProfiler()->endQuery($queryId);
+
+        return $result;
+    }
+
+    public function setProfiler(Profiler $p)
+    {
+        $this->profiler = $p;
+        return $this;
+    }
+
+    public function getProfiler()
+    {
+        return $this->profiler;
+    }
+}

--- a/src/BjyProfiler/Db/Adapter/Driver/Sqlsrv/ProfilingStatement.php
+++ b/src/BjyProfiler/Db/Adapter/Driver/Sqlsrv/ProfilingStatement.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace BjyProfiler\Db\Adapter\Driver\Pgsql;
+
+use BjyProfiler\Db\Profiler\Profiler;
+use Zend\Db\Adapter\Driver\Pgsql\Statement;
+
+class ProfilingStatement extends Statement
+{
+    protected $profiler;
+
+    public function execute($parameters = null)
+    {
+        $queryId = $this->getProfiler()->startQuery($this->getSql());
+        $result = parent::execute($parameters);
+        $this->getProfiler()->endQuery($queryId);
+
+        return $result;
+    }
+
+    public function setProfiler(Profiler $p)
+    {
+        $this->profiler = $p;
+        return $this;
+    }
+
+    public function getProfiler()
+    {
+        return $this->profiler;
+    }
+}

--- a/src/BjyProfiler/Db/Adapter/ProfilingAdapter.php
+++ b/src/BjyProfiler/Db/Adapter/ProfilingAdapter.php
@@ -28,4 +28,39 @@ class ProfilingAdapter extends Adapter
     {
         return $this->profiler;
     }
+
+
+    public function injectProfilingStatementPrototype()
+    {
+        $profiler = $this->getProfiler();
+        if (!$profiler instanceof Profiler) {
+            throw new \InvalidArgumentException('No profiler attached!');
+        }
+
+        $driver = $this->getDriver();
+        if (method_exists($driver, 'registerStatementPrototype')) {
+            $driverName = get_class($driver);
+            switch ($driverName) {
+                case 'Zend\Db\Adapter\Driver\Mysqli\Mysqli':
+                    $statementPrototype = new Driver\Mysqli\ProfilingStatement();
+                    break;
+                case 'Zend\Db\Adapter\Driver\Sqlsrv\Sqlsrv':
+                    $statementPrototype = new Driver\Sqlsrv\ProfilingStatement();
+                    break;
+                case 'Zend\Db\Adapter\Driver\Pgsql\Pgsql':
+                    $statementPrototype = new Driver\Pgsql\ProfilingStatement();
+                    break;
+                case 'Zend\Db\Adapter\Driver\Pdo\Pdo':
+                default:
+                    $statementPrototype = new Driver\Pdo\ProfilingStatement();
+            }
+
+            if(isset($statementPrototype)) {
+                $statementPrototype->setProfiler($this->getProfiler());
+                $driver->registerStatementPrototype($statementPrototype);
+            }
+
+        }
+    }
 }
+


### PR DESCRIPTION
Currently, BjyProfiler does not detect prepared statements, as those don't use the Adapter's query method.  I've added an extension of the `Statement` class for each `Zend\Db\Adapter\Driver` bundled with ZF2, and a method on the `ProfilingAdapter` to inject the correct `ProfilingStatement` class into the driver. 

Usage:

```
<?php

$dbParams = array(
    'database'  => 'changeme',
    'username'  => 'changeme',
    'password'  => 'changeme',
    'hostname'  => 'localhost'
);

return array(
    'service_manager' => array(
        'factories' => array(
            'Zend\Db\Adapter\Adapter' => function ($sm) use ($dbParams) {
                $adapter = new BjyProfiler\Db\Adapter\ProfilingAdapter(array(
                    'driver'    => 'pdo',
                    'dsn'       => 'mysql:dbname='.$dbParams['database'].';host='.$dbParams['hostname'],
                    'database'  => $dbParams['database'],
                    'username'  => $dbParams['username'],
                    'password'  => $dbParams['password'],
                    'hostname'  => $dbParams['hostname'],
                ));

                $adapter->setProfiler(new BjyProfiler\Db\Profiler\Profiler);
                // Added this line:
                $adapter->injectProfilingStatementPrototype();
                return $adapter;
            },
        ),
    ),
);
```

There may be a better way to register the statement prototype than this, but it has to be done after the profiler is injected into the Adapter, so it can't be done during Adapter instantiation (ie: by overriding Adapter::createDriverFromParameters)
