### PR TITLE
Add a default module config file

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -1,0 +1,21 @@
+<?php
+return array(
+    'service_manager' => array(
+        'factories' => array(
+            'Zend\Db\Adapter\Adapter' => function ($sm) {
+                $config = $sm->get('Configuration');
+                if(!isset($config['db'])){
+                    return false;
+                }
+                if(class_exists('BjyProfiler\Db\Adapter\ProfilingAdapter')){
+                    $adapter = new BjyProfiler\Db\Adapter\ProfilingAdapter($config['db']);
+                    $adapter->setProfiler(new BjyProfiler\Db\Profiler\Profiler);
+                    $adapter->injectProfilingStatementPrototype();
+                } else {
+                    $adapter = new Zend\Db\Adapter\Adapter($config['db']);
+                }
+                return $adapter;
+            },
+        ),
+    ),
+);


### PR DESCRIPTION
Put the config file to /project/config/autoload folder, and load BjyProfiler module, will enable BjyProfiler automatic and compatible with Db Adapter service manager
