### PR TITLE
To be compatible with packgist, composer.json must be updated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "bjyoungblood/BjyProfiler",
+    "name": "bjyoungblood/bjyoungblood/bjy-profiler",
     "description": "Database profiler for Zend\\Db (also plugin for ZendDeveloperTools)",
     "type": "library",
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "bjyoungblood/bjyoungblood/bjy-profiler",
+    "name": "bjyoungblood/bjy-profiler",
     "description": "Database profiler for Zend\\Db (also plugin for ZendDeveloperTools)",
     "type": "library",
     "keywords": [


### PR DESCRIPTION
Hi, the composer.json seems to be outdated. Following the help message while added bjy-profiler to my local packagist, a help message recommand the following name : bjyoungblood/bjy-profiler
