### PR TITLE
Update Module.php

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -4,6 +4,11 @@ namespace BjyProfiler;
 
 class Module
 {
+    public function getConfig()
+    {
+        return include __DIR__ . '/config/module.config.php';
+    }
+
     public function getAutoloaderConfig()
     {
         return array(


### PR DESCRIPTION
Without the getConfig() the configuration for this module (mainly the alteration of Zend\Db\Adapter\Adapter) won't be loaded and the profiling can't be used out of the box from ZendDeveloperTools
