### PR TITLE
Add enable/disable to BjyProfiler\Db\Profiler\Profiler 

### DIFF
--- a/src/BjyProfiler/Db/Profiler/Profiler.php
+++ b/src/BjyProfiler/Db/Profiler/Profiler.php
@@ -37,6 +37,18 @@ class Profiler
         $this->filterTypes = 127;
     }
 
+    public function enable()
+    {
+        $this->enabled = true;
+        return $this;
+    }
+
+    public function disable()
+    {
+        $this->enabled = false;
+        return $this;
+    }
+
     public function setFilterQueryType($queryTypes = null)
     {
         $this->filterTypes = $queryTypes;


### PR DESCRIPTION
In some of my unit tests I need to use this profiler.   However, I want the profiler to be disabled for the setup and teardown of databases fixtures for system under test.  That way the fixtures can be modified by other programmers but without affecting the expected query profiles in the unit tests.

This commit is a trivial change but adds two new methods so that the profiler can be easily disabled and re-enabled.

``` php
  $db->getProfiler()->disable();
...
  $db->getProfiler()->enable();
```

This is easier to read than the current workaround, which works since the class constructor accepts a boolean that in turn sets the `$enabled` property.

``` php
  $db->setProfiler(new Profiler(false))) // disable
...
  $db->setProfiler(new Profiler(true))) // enable
```

The class already contained logic to correctly enable or disable profiling based on the value of the `$enabled` property.
