### PR TITLE
IBM DB2 adapter

### DIFF
--- a/src/BjyProfiler/Db/Adapter/Driver/IbmDb2/ProfilingStatement.php
+++ b/src/BjyProfiler/Db/Adapter/Driver/IbmDb2/ProfilingStatement.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace BjyProfiler\Db\Adapter\Driver\IbmDb2;
+
+use Zend\Db\Adapter\Profiler\ProfilerInterface;
+use Zend\Db\Adapter\Driver\IbmDb2\Statement;
+
+class ProfilingStatement extends Statement
+{
+    protected $profiler;
+
+    public function execute($parameters = null)
+    {
+        if ($parameters === null) {
+            if ($this->parameterContainer != null) {
+                $saveParams = (array) $this->parameterContainer->getNamedArray();
+            } else {
+                $saveParams = array();
+            }
+        } else {
+            $saveParams = $parameters;
+        }
+
+        if (version_compare('5.3.6', phpversion(), '<=')) {
+            $stack = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+        } else {
+            $stack = array();
+        }
+
+        $queryId = $this->getProfiler()->startQuery($this->getSql(), $saveParams, $stack);
+        $result = parent::execute($parameters);
+        $this->getProfiler()->endQuery($queryId);
+
+        return $result;
+    }
+
+    public function setProfiler(ProfilerInterface $p)
+    {
+        $this->profiler = $p;
+        return $this;
+    }
+
+    public function getProfiler()
+    {
+        return $this->profiler;
+    }
+}

--- a/src/BjyProfiler/Db/Adapter/ProfilingAdapter.php
+++ b/src/BjyProfiler/Db/Adapter/ProfilingAdapter.php
@@ -33,6 +33,9 @@ class ProfilingAdapter extends Adapter
         if (method_exists($driver, 'registerStatementPrototype')) {
             $driverName = get_class($driver);
             switch ($driverName) {
+                case 'Zend\Db\Adapter\Driver\IbmDb2\IbmDb2':
+                    $statementPrototype = new Driver\IbmDb2\ProfilingStatement();
+                    break;
                 case 'Zend\Db\Adapter\Driver\Mysqli\Mysqli':
                     $defaults = array('buffer_results' => false);
                     $options = array_intersect_key(array_merge($defaults, $options), $defaults);


### PR DESCRIPTION
Zend Framework 2.1 now ships with an IBM DB2 adapter.
- Initial commit zendframework/zf2@823e727097e10de8373f36945fa9a3d35672f553

I've added a Statement Prototype class for IBM DB2 based on the Statement Prototypes for other drivers in BjyProfiler, and hooked it in to the Profiling Adapter class.
