### PR TITLE
Logging profiler logs in start/end query functions.

### DIFF
--- a/src/BjyProfiler/Db/Profiler/LoggingProfiler.php
+++ b/src/BjyProfiler/Db/Profiler/LoggingProfiler.php
@@ -89,8 +89,8 @@ class LoggingProfiler extends Profiler
 
     private function trimToMaxQueries() {
         $maxProfiles = $this->getMaxProfiles();
-        if ($maxProfiles > -1) {
-            if (count($this->profiles) > $maxProfiles) $this->profiles = array();
+        if ($maxProfiles > -1 && count($this->profiles) > $maxProfiles) {
+            array_shift($this->profiles);
         }
     }
 

--- a/src/BjyProfiler/Db/Profiler/LoggingProfiler.php
+++ b/src/BjyProfiler/Db/Profiler/LoggingProfiler.php
@@ -62,8 +62,9 @@ class LoggingProfiler extends Profiler
     }
 
     public function endQuery() {
-        $this->logEnd();
         parent::endQuery();
+        $this->logEnd();
+        $this->trimToMaxQueries();
     }
 
     private function logStart() {
@@ -84,7 +85,9 @@ class LoggingProfiler extends Profiler
             'Query finished',
             array_intersect_key($lastQuery->toArray(), array_flip($this->getParametersFinish()))
         );
+    }
 
+    private function trimToMaxQueries() {
         $maxProfiles = $this->getMaxProfiles();
         if ($maxProfiles > -1) {
             if (count($this->profiles) > $maxProfiles) $this->profiles = array();

--- a/src/BjyProfiler/Db/Profiler/LoggingProfiler.php
+++ b/src/BjyProfiler/Db/Profiler/LoggingProfiler.php
@@ -56,10 +56,17 @@ class LoggingProfiler extends Profiler
         if (isset($options['parametersFinish'])) $this->setParametersFinish($options['parametersFinish']);
     }
 
-    public function profilerStart($target)
-    {
-        parent::profilerStart($target);
+    public function startQuery($sql, $parameters = null, $stack = null) {
+        parent::startQuery($sql, $parameters, $stack);
+        $this->logStart();
+    }
 
+    public function endQuery() {
+        $this->logEnd();
+        parent::endQuery();
+    }
+
+    private function logStart() {
         /** @var Query $lastQuery */
         $lastQuery = end($this->profiles);
         $this->getLogger()->log(
@@ -69,10 +76,7 @@ class LoggingProfiler extends Profiler
         );
     }
 
-    public function profilerFinish()
-    {
-        parent::profilerFinish();
-
+    private function logEnd() {
         /** @var Query $lastQuery */
         $lastQuery = end($this->profiles);
         $this->getLogger()->log(


### PR DESCRIPTION
This fixes missing log output for QUERY_MODE_EXECUTE (#41) and additionally
means that the the "prepare" query is logged in the the same way as users
normally see on the zend debug toolbar.
