### PR TITLE
Fix missing parameters in profiler output.

### DIFF
--- a/src/BjyProfiler/Db/Profiler/Profiler.php
+++ b/src/BjyProfiler/Db/Profiler/Profiler.php
@@ -135,7 +135,7 @@ class Profiler implements ProfilerInterface
     public function profilerStart($target)
     {
         $sql = $target->getSql();
-        $params = $target->getParameterContainer();
+        $params = $target->getParameterContainer()->getNamedArray();
         $this->startQuery($sql, $params);
     }
 


### PR DESCRIPTION
Passing `ParameterContainer` straight to logger causes losing some parameters.
`ParameterContainer` stops iterating once it reaches parameter with `false` value.
Calling `getNamedArray()` is tested way to fix it.
See https://github.com/zendframework/zf2/blob/release-2.3.1/library/Zend/Db/Adapter/Driver/Pdo/Statement.php#L269
